### PR TITLE
Fix: Prevent > shortcut from corrupting lines with scheduling tags

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,5 +1,19 @@
 /* Task Manager Plugin Styles */
 
+/* Container for all task decorations - wraps as a single unit */
+.task-decorations-container {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  margin-left: 4px;
+}
+
+/* Remove left margin from first child since container has it */
+.task-decorations-container > :first-child {
+  margin-left: 0;
+}
+
 /* Info button styling */
 .task-info-button {
   display: inline-flex;
@@ -98,13 +112,28 @@
   font-weight: 400;
   transition: background 0.15s ease;
   user-select: none;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
   white-space: nowrap;
   vertical-align: baseline;
 }
 
 .task-note-button:hover {
   background: rgba(0, 0, 0, 0.1);
+}
+
+.task-note-button-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  margin-right: 4px;
+}
+
+.task-note-button-icon svg {
+  width: 10px;
+  height: 10px;
 }
 
 /* Schedule tag pills */


### PR DESCRIPTION
## Problem
The `>` schedule shortcut was incorrectly triggering when clicking on lines that already contained `[> DATE]` scheduling tags. When the cursor was positioned after the `>` in a tag like `[> 2026-01-24]`, the trigger would fire and corrupt the line by removing text from that position.

## Solution
Added a check in `ScheduleShortcutSuggest.onTrigger()` to ignore `>` characters that are preceded by `[` (indicating a scheduling tag bracket).

## Additional Changes
- Add `taskId` to task note frontmatter for future reference/lookup
- Add `updateTaskNoteSourceFile()` to sync task notes when tasks are scheduled to new dates
- Comprehensive documentation for task note source synchronization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix and scheduling improvements**
> 
> - Add `ScheduleShortcutSuggest` with guard to ignore `>` preceded by `[` so scheduling tag edits aren’t corrupted
> - Refine `TaskScheduler.scheduleTask()` to derive `fromDate` from active file, detect existing target task by `id`, update its `[< DATE]` tag instead of duplicating, and then mark the source with `[> DATE]`
> 
> **Task Note enhancements**
> 
> - `openOrCreateTaskNote()` now accepts `taskId` and writes `taskId` to frontmatter
> - New `updateTaskNoteSourceFile()` keeps task notes in sync on reschedule (updates `sourceFile`, `scheduled`, and the body "**Source:**" link)
> 
> **UI/UX**
> 
> - Introduce unified `TaskDecorationsWidget` to render `notes` button, schedule pills, and info button together; hide raw schedule tags in-editor
> - Replace inline SVG constants with shared `Icons`; update slash-command icons
> - Add CSS for `.task-decorations-container`, note button icon, and pill layout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac4f67d4a4f6c3bcdf5e8a96d50ec0c43d208b2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->