### PR TITLE
fix: include scheduled [>] and cancelled [-] tasks in COMPLETED_PATTERN

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ const TaskUtils = {
   ID_PATTERN: /\[id::([^\]]+)\]/,
   PARENT_ID_PATTERN: /\[parent::([^\]]+)\]/,
   METADATA_PATTERN: /\s*\[(?:id|parent|uid)::[^\]]+\]/g,
-  COMPLETED_PATTERN: /^[\t]*- \[[xX]\]/,
+  COMPLETED_PATTERN: /^[\t]*- \[[xX\->]\]/,
   TIMEBLOCK_PATTERN: /^- \[.\]\s*(\d{2}):(\d{2}) - (\d{2}):(\d{2})/,
   CALENDAR_EVENT_PATTERN: /^[\t]*- \[c\]/,
 


### PR DESCRIPTION
Tasks with `[>]` (scheduled away) or `[-]` (cancelled) checkboxes were not being recognized as completed, causing them to stay with incomplete tasks instead of being moved to the archived callout during sorting.

Fixes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task completion detection to recognize additional marker formats beyond standard checkboxes, ensuring more variations of task completion symbols are properly identified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->