### PR TITLE
fix: handle callout-prefixed tasks in extractTaskTextFromLine

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -939,7 +939,8 @@ const TaskNoteManager = {
 
   extractTaskTextFromLine(line) {
     // Match any task marker (space, x, >, /, -, etc.)
-    const taskMatch = line.match(/^- \[.\]\s*(.+)$/);
+    // Also match tasks in callouts (prefixed with "> ") for archive support
+    const taskMatch = line.match(/^(?:>\s*)?- \[.\]\s*(.+)$/);
     if (!taskMatch) return null;
     return this.cleanTaskText(taskMatch[1]);
   },


### PR DESCRIPTION
## Problem

When tasks are rescheduled from a daily note's archive callout (e.g., scheduling a task from 1/24 to 1/26), the task note's `sourceFile` and `scheduled` frontmatter fields were not being updated.

## Root Cause

The `extractTaskTextFromLine` function uses a regex that expects task lines to start with `- [`. However, tasks in the archive callout are prefixed with `> `:

```
> - [>] 12:00 - 15:00 Self evaluation #sei [id:: t-r352lle7] [> 2026-01-25]
```

The regex `^- \[.\]` did not match these lines, causing `extractTaskTextFromLine` to return `null`. This meant `updateTaskNoteSourceFile` was never called when scheduling tasks from the archive.

## Solution

Updated the regex to optionally match the callout prefix:

```javascript
// Before
const taskMatch = line.match(/^- \[.\]\s*(.+)$/);

// After  
const taskMatch = line.match(/^(?:>\s*)?- \[.\]\s*(.+)$/);
```

The `(?:>\s*)?` makes the `> ` prefix optional, matching both normal tasks and tasks in callouts.

## Testing

- Verified build succeeds
- Installed to vault for manual testing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task extraction now supports callout formatting, allowing tasks prefixed with ">" to be properly recognized and extracted alongside standard task formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->