### PR TITLE
Fix: stop assigning IDs to plain bullets

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -992,41 +992,6 @@ class TaskManagerPlugin extends Plugin {
     const line = editor.getLine(lineNum);
     if (!line) return;
 
-    // Handle subnotes (indented bullets without checkbox)
-    if (TaskUtils.isSubnote(line)) {
-      let newLine = line;
-      let modified = false;
-
-      // Add ID if missing (with note prefix)
-      if (this.settings.enableTaskIds && !TaskUtils.extractId(line)) {
-        newLine = TaskUtils.addId(newLine, TaskUtils.generateNoteId(this.settings));
-        modified = true;
-      }
-
-      // Add parent link if missing
-      if (this.settings.enableParentChildLinking && !TaskUtils.extractParentId(newLine)) {
-        let parentId = null;
-        for (let i = lineNum - 1; i >= 0; i--) {
-          const prevLine = editor.getLine(i);
-          if (TaskUtils.isParentTask(prevLine)) {
-            parentId = TaskUtils.extractId(prevLine);
-            break;
-          }
-        }
-        if (parentId) {
-          newLine = TaskUtils.addParentId(newLine, parentId);
-          modified = true;
-        }
-      }
-
-      if (modified) {
-        this.isProcessing = true;
-        editor.setLine(lineNum, newLine);
-        setTimeout(() => { this.isProcessing = false; }, 50);
-      }
-      return;
-    }
-
     // Only process task lines (but NOT calendar events)
     if (!TaskUtils.isTask(line)) return;
     if (TaskUtils.isCalendarEvent(line)) return;

--- a/src/services/task-id-manager.ts
+++ b/src/services/task-id-manager.ts
@@ -1,4 +1,4 @@
-import { addId, extractId, generateId, generateNoteId, isCalendarEvent, isSubnote, isTask } from '../utils/task-utils';
+import { addId, extractId, generateId, isCalendarEvent, isTask } from '../utils/task-utils';
 import type { TaskManagerSettings } from '../types';
 
 // ============================================================================
@@ -21,10 +21,6 @@ export function processContent(content: string, settings: TaskManagerSettings): 
     if (isTask(line)) {
       if (!extractId(line)) {
         line = addId(line, generateId(settings));
-      }
-    } else if (isSubnote(line)) {
-      if (!extractId(line)) {
-        line = addId(line, generateNoteId(settings));
       }
     }
 


### PR DESCRIPTION
## Summary
- Removes subnote ID assignment from `processContent()` in task-id-manager.ts
- Removes subnote ID/parent assignment from `processLineOnLeave()` in main.ts
- Only task lines with checkboxes (`- [x]`, `- [ ]`, etc.) now receive IDs

## Test plan
- [ ] Create a plain bullet `- some text` and verify no ID is added
- [ ] Create an indented plain bullet under a task and verify no ID is added
- [ ] Create a task `- [ ] some text` and verify it still gets an ID assigned
- [ ] Run "Assign IDs to all tasks" command and verify plain bullets are skipped

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavior change that only removes automatic metadata insertion on non-task lines; low risk aside from users who relied on IDs/parent links on subnotes.
> 
> **Overview**
> Stops treating indented plain bullets (“subnotes”) as ID-bearing items.
> 
> ID assignment now applies **only** to checkbox task lines: `processLineOnLeave()` no longer adds IDs/`[parent::]` to subnotes, and `TaskIdManager.processContent()` no longer generates note-prefixed IDs for subnotes, preventing plain bullets from being mutated during both live editing and bulk “assign IDs” runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc929cec6b835454b2a86e50baf9f337414a9533. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed automatic ID and parent link generation for subnotes during line processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->